### PR TITLE
test: add command test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "modulePathIgnorePatterns": [
-      "<rootDir>/assets/"
+    "rootDir": "src",
+    "coverageDirectory": "../coverage",
+    "collectCoverageFrom": [
+      "**/*.js"
     ]
   },
   "prettier": {

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -9,7 +9,7 @@ module.exports = {
       parameters,
       system: { run },
       strings,
-      filesystem: { path, dir, write, copyAsync },
+      filesystem: { path, dir, write, read, copyAsync },
       print: { success, error, muted },
       prompt,
       meta,
@@ -58,6 +58,7 @@ module.exports = {
       },
     ])
     userInput = Object.assign(
+      {},
       userInput,
       await prompt.ask([
         {
@@ -180,7 +181,7 @@ module.exports = {
 
     await Promise.all(asyncOperations)
 
-    const packageJson = require(`${userInput.appDir}/package.json`)
+    const packageJson = JSON.parse(read(`${userInput.appDir}/package.json`))
     const newScripts = userInput.pkgJsonScripts.reduce(
       (acc, scr) => ({ ...acc, ...scr }),
       {}

--- a/src/commands/generate.test.js
+++ b/src/commands/generate.test.js
@@ -1,0 +1,140 @@
+const { strings } = require('gluegun');
+const generate = require('./generate');
+
+const userInput = {
+  projectName: 'project-name',
+  projectScope: 'scope',
+  framework: 'express',
+  projectLanguage: 'TS',
+  moduleType: 'CJS',
+  features: [
+    'JSLinters',
+    'huskyHooks',
+    'commitMsgLint',
+    'preCommit',
+    'prePush',
+    'dockerizeWorkflow'
+  ]
+};
+
+const toolbox = {
+  filesystem: {
+    copyAsync: async (from, to, options) => {},
+    dir: (path, criteria) => {},
+    path: (...args) => '',
+    read: (path) => JSON.stringify({ scripts: {}, jest: {} }),
+    write: (path, data, options) => {},
+  },
+  parameters: {
+    plugin: 'node-cli',
+    command: 'generate',
+    array: [ 'project-name' ],
+    options: {},
+    raw: [
+      '/path/to/node',
+      '/path/to/project/bin/node-cli',
+      'generate',
+      'project-name',
+    ],
+    argv: [
+      '/path/to/node',
+      '/path/to/project/bin/node-cli',
+      'generate',
+      'project-name'
+    ],
+    first: 'project-name',
+    second: undefined,
+    third: undefined,
+    string: 'project-name'
+  },
+  print: {
+    success: (msg) => {},
+    error: (msg) => {},
+    muted: (msg) => {},
+  },
+  prompt: {
+    ask: jest.fn(async (questions) => {
+      const answers = questions.map(q => {
+        const answer = [q.format, q.result]
+          .filter(Boolean)
+          .reduce((val, fn) => fn(val), userInput[q.name])
+        return [q.name, answer];
+      });
+      return Object.fromEntries(answers);
+    }),
+  },
+  strings,
+  system: {
+    run: (cmd) => ''
+  },
+  meta: {
+    src: '/path/to/project/src',
+  },
+  // Extensions
+  installFramework: async () => {},
+  installNest: async () => {},
+  jsLinters: () => ({ syncOperations: () => {}, asyncOperations: async () => {} }),
+  jestConfig: () => ({ syncOperations: () => {}, asyncOperations: async () => {} }),
+  setupTs: () => ({ syncOperations: () => {}, asyncOperations: async () => {} }),
+  setupHusky: () => ({ syncOperations: () => {}, asyncOperations: async () => {} }),
+  dockerizeWorkflow: () => ({ syncOperations: () => {}, asyncOperations: async () => {} }),
+};
+
+describe('generate', () => {
+  it('should be defined', () => {
+    expect(generate).toBeDefined();
+    expect(generate.name).toBeDefined();
+    expect(generate.description).toBeDefined();
+    expect(generate.alias).toBeDefined();
+    expect(generate.run).toBeDefined();
+  });
+
+  describe('run', () => {
+    beforeAll(async () => {
+      await generate.run(toolbox);
+    });
+
+    it('should prompt the user twice', () => {
+      expect(toolbox.prompt.ask).toHaveBeenCalledTimes(2);
+    });
+
+    it('should ask for the project name, scope and framework', async () => {
+      const questions = toolbox.prompt.ask.mock.calls[0][0];
+
+      expect(questions).toHaveLength(3);
+      expect(questions[0].name).toBe('projectName');
+      expect(questions[1].name).toBe('projectScope');
+      expect(questions[2].name).toBe('framework');
+
+      const answers = await toolbox.prompt.ask.mock.results[0].value;
+      expect(answers).toEqual({
+        projectName: 'project-name',
+        projectScope: 'scope',
+        framework: 'express'
+      });
+    });
+
+    it('should ask for the project language, module system and app features', async () => {
+      const questions = toolbox.prompt.ask.mock.calls[1][0];
+
+      expect(questions).toHaveLength(3);
+      expect(questions[0].name).toBe('projectLanguage');
+      expect(questions[1].name).toBe('moduleType');
+      expect(questions[2].name).toBe('features');
+
+      const answers = await toolbox.prompt.ask.mock.results[1].value;
+      expect(answers).toEqual({
+        projectLanguage: 'TS',
+        moduleType: 'CJS',
+        features: [
+          'JSLinters',
+          'huskyHooks',
+          'commitMsgLint',
+          'preCommit',
+          'prePush',
+          'dockerizeWorkflow'
+        ]
+      });
+    });
+  });
+});

--- a/src/commands/node-cli.test.js
+++ b/src/commands/node-cli.test.js
@@ -1,0 +1,25 @@
+const nodeCli = require('./node-cli');
+
+const toolbox = {
+  print: {
+    info: jest.fn((msg) => {}),
+  },
+};
+
+describe('node-cli', () => {
+  it('should be defined', () => {
+    expect(nodeCli).toBeDefined();
+    expect(nodeCli.name).toBeDefined();
+    expect(nodeCli.run).toBeDefined();
+  });
+
+  describe('run', () => {
+    beforeAll(async () => {
+      await nodeCli.run(toolbox);
+    });
+
+    it('should print info on using the cli', () => {
+      expect(toolbox.print.info).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Had to change the dynamic `require` in order to mock the loading of `package.json` [here](https://github.com/MentorMate/node-pipeline-template/pull/21/files#diff-a541ed575a3e274a0cb519217afd8fc733f77618eb9b117d3df4f553b5b36304L183).

Let's try not to mutate any inputs / returns. In [this case](https://github.com/MentorMate/node-pipeline-template/pull/21/files#diff-a541ed575a3e274a0cb519217afd8fc733f77618eb9b117d3df4f553b5b36304L60) the mutation of `userInput` updated the return value that jest was storing for the function call and so it wasn't possible to test it.

![image](https://user-images.githubusercontent.com/13519772/198255748-6915176e-853c-4742-94a6-87c3e2c3519c.png)
