### PR TITLE
test: add husky-setup-extension tests

### DIFF
--- a/src/extensions/husky-setup-extension.js
+++ b/src/extensions/husky-setup-extension.js
@@ -11,8 +11,7 @@ module.exports = (toolbox) => {
   }) => {
     const {
       filesystem: { dir, copyAsync },
-      system: { run },
-      print: { error, success, muted },
+      print: { success, muted },
     } = toolbox
 
     const appHuskyPath = `${appDir}/.husky`

--- a/src/extensions/husky-setup-extension.test.js
+++ b/src/extensions/husky-setup-extension.test.js
@@ -1,61 +1,287 @@
-const extend = require('./husky-setup-extension');
-const { createToolboxMock, createExtensionInput } = require('../utils/test/mocks');
+const extend = require('./husky-setup-extension')
+const {
+  createToolboxMock,
+  createExtensionInput,
+} = require('../utils/test/mocks')
 
 describe('husky-setup-extension', () => {
+  let toolbox
+
+  beforeEach(() => {
+    toolbox = createToolboxMock()
+    extend(toolbox)
+  })
+
   it('should be defined', () => {
-    expect(extend).toBeDefined();
-  });
+    expect(extend).toBeDefined()
+  })
 
   it('should set setupHusky on toolbox', () => {
-    const toolbox = {};
-    extend(toolbox);
-    expect(toolbox.setupHusky).toBeDefined();
-  });
+    expect(toolbox.setupHusky).toBeDefined()
+  })
 
   describe('setupHusky', () => {
-    const toolbox = createToolboxMock();
+    let input
+    let ops
 
     beforeAll(() => {
-      extend(toolbox);
-    });
+      input = createExtensionInput()
+    })
+
+    beforeEach(() => {
+      ops = toolbox.setupHusky(input)
+    })
 
     it('should return syncOperations and asyncOperations when the extension is called', () => {
-      const ops = toolbox.setupHusky(createExtensionInput());
-      expect(ops.syncOperations).toBeDefined();
-      expect(ops.asyncOperations).toBeDefined();
-    });
+      expect(ops.syncOperations).toBeDefined()
+      expect(ops.asyncOperations).toBeDefined()
+    })
 
     describe('syncOperations', () => {
-      const toolbox = createToolboxMock();
-      const input = createExtensionInput();
+      let scripts
+      let packages
 
       beforeAll(() => {
-        extend(toolbox);
-        toolbox.setupHusky(input).syncOperations();
-      });
+        input.features = []
+      })
 
-      it('should add npm packages and scripts', () => {
-        expect(input.pkgJsonInstalls.length).toBeGreaterThan(0);
-        expect(input.pkgJsonScripts.length).toBeGreaterThan(0);
-      });
-    });
+      beforeEach(() => {
+        ops.syncOperations()
+        scripts = Object.assign({}, ...input.pkgJsonScripts)
+        packages = input.pkgJsonInstalls.map((s) => s.split(' ')).flat(1)
+      })
+
+      describe('when the language is TypeScript', () => {
+        beforeAll(() => {
+          input.projectLanguage = 'TS'
+        })
+
+        it('should add a prepare script which builds the app', () => {
+          expect(scripts['prepare']).toBe('husky install && npm run build')
+        })
+      })
+
+      describe('when the language is JavaScript', () => {
+        beforeAll(() => {
+          input.projectLanguage = 'JS'
+        })
+
+        it('should add a prepare script', () => {
+          expect(scripts['prepare']).toBe('husky install')
+        })
+      })
+
+      it('should add the husky package', () => {
+        expect(packages).toContain('husky')
+      })
+
+      describe('when the features include commit message linting', () => {
+        beforeAll(() => {
+          input.features = ['commitMsgLint']
+        })
+
+        it('should add a commit message validation script', () => {
+          expect(scripts['validate:commit-message']).toBe(
+            'commitlint --edit $1'
+          )
+        })
+
+        it('should add the @commitlint/cli package', () => {
+          expect(packages).toContain('@commitlint/cli')
+        })
+
+        it('should add the @commitlint/config-conventional package', () => {
+          expect(packages).toContain('@commitlint/config-conventional')
+        })
+
+        it('should add the commitizen package', () => {
+          expect(packages).toContain('commitizen')
+        })
+
+        it('should add the cz-conventional-changelog package', () => {
+          expect(packages).toContain('cz-conventional-changelog')
+        })
+      })
+
+      describe('when the features include pre commit', () => {
+        beforeAll(() => {
+          input.features = ['preCommit']
+        })
+
+        it('should add the init secrets script', () => {
+          expect(scripts['initsecrets']).toBeDefined()
+        })
+
+        it('should add the lint-staged package', () => {
+          expect(packages).toContain('lint-staged')
+        })
+
+        it('should add the shellcheck package', () => {
+          expect(packages).toContain('shellcheck')
+        })
+
+        it('should add the sort-package-json package', () => {
+          expect(packages).toContain('sort-package-json')
+        })
+
+        it('should add the @ls-lint/ls-lint package', () => {
+          expect(packages).toContain('@ls-lint/ls-lint')
+        })
+      })
+    })
 
     describe('asyncOperations', () => {
-      let toolbox = createToolboxMock();
+      let assetsPath
+      let appDir
+      let appHuskyPath
+      let assetHuskyPath
 
-      beforeAll(async () => {
-        toolbox.print.muted = jest.fn(() => {});
-        toolbox.print.success = jest.fn(() => {});
-        toolbox.print.error = jest.fn(() => {});
-        extend(toolbox);
-        await toolbox.setupHusky(createExtensionInput()).asyncOperations();
-      });
+      beforeAll(() => {
+        assetsPath = input.assetsPath
+        appDir = input.appDir
+        appHuskyPath = `${appDir}/.husky`
+        assetHuskyPath = `${assetsPath}/.husky`
+        input.features = []
+      })
+
+      beforeEach(() => {
+        toolbox.print.muted = jest.fn(() => {})
+        toolbox.print.success = jest.fn(() => {})
+        toolbox.print.error = jest.fn(() => {})
+        toolbox.filesystem.dir = jest.fn(() => {})
+        toolbox.filesystem.copyAsync = jest.fn(() => {})
+      })
+
+      beforeEach(async () => {
+        await toolbox.setupHusky(input).asyncOperations()
+      })
 
       it('should print a muted and a success message', () => {
-        expect(toolbox.print.muted).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.success).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.error).not.toHaveBeenCalled();
-      });
-    });
-  });
-});
+        expect(toolbox.print.muted).toHaveBeenCalledTimes(1)
+        expect(toolbox.print.success).toHaveBeenCalledTimes(1)
+        expect(toolbox.print.error).not.toHaveBeenCalled()
+      })
+
+      it('should create a .husky directory', () => {
+        expect(toolbox.filesystem.dir).toHaveBeenCalledWith(appHuskyPath)
+      })
+
+      it('should copy the husky .gitignore', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${assetHuskyPath}/.project-gitignr`,
+          `${appHuskyPath}/.gitignore`
+        )
+      })
+
+      describe('when the features include commitMsgLint', () => {
+        beforeAll(async () => {
+          input.features = ['commitMsgLint']
+        })
+
+        it('should copy the commit lint config file', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetsPath}/.commitlintrc.js`,
+            `${appDir}/.commitlintrc.js`
+          )
+        })
+
+        it('should copy the Commitzen config file', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetsPath}/.czrc`,
+            `${appDir}/.czrc`
+          )
+        })
+
+        it('should copy the commit msg hook', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetHuskyPath}/commit-msg`,
+            `${appHuskyPath}/commit-msg`
+          )
+        })
+      })
+
+      describe('when the features include preCommit', () => {
+        beforeAll(async () => {
+          input.features = ['preCommit']
+        })
+
+        it('should create a scripts directory', () => {
+          expect(toolbox.filesystem.dir).toHaveBeenCalledWith(
+            `${appDir}/scripts`
+          )
+        })
+
+        it('should copy the pre-commit hook', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetHuskyPath}/pre-commit`,
+            `${appHuskyPath}/pre-commit`
+          )
+        })
+
+        it('should copy the lintstaged config', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetsPath}/.lintstagedrc`,
+            `${appDir}/.lintstagedrc`
+          )
+        })
+
+        it('should copy the ls-lint config', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetsPath}/.ls-lint.yml`,
+            `${appDir}/.ls-lint.yml`
+          )
+        })
+
+        it('should copy the pre-commit config', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetsPath}/.pre-commit-config.yaml`,
+            `${appDir}/.pre-commit-config.yaml`
+          )
+        })
+
+        it('should copy the detect-secrets script', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetsPath}/detect-secrets.sh`,
+            `${appDir}/scripts/detect-secrets.sh`
+          )
+        })
+
+        it('should copy the secrets baseline file', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetsPath}/.secrets.baseline`,
+            `${appDir}/.secrets.baseline`
+          )
+        })
+      })
+
+      describe('when the features include prePush', () => {
+        beforeAll(async () => {
+          input.features = ['prePush']
+        })
+
+        it('should copy the pre-push hook', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${assetHuskyPath}/pre-push`,
+            `${appHuskyPath}/pre-push`
+          )
+        })
+      })
+
+      describe('when an error is thrown', () => {
+        const error = new Error('the-error')
+
+        beforeEach(async () => {
+          toolbox.filesystem.copyAsync = jest.fn(() => {
+            throw error
+          })
+        })
+
+        it('should rethrow the error with an added user-friendly message', () => {
+          expect(toolbox.setupHusky(input).asyncOperations()).rejects.toThrow(
+            `An error has occurred while creating husky hooks: ${error}`
+          )
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
```
 PASS  src/extensions/husky-setup-extension.test.js
  husky-setup-extension
    ✓ should be defined (2 ms)
    ✓ should set setupHusky on toolbox
    setupHusky
      ✓ should return syncOperations and asyncOperations when the extension is called (1 ms)
      syncOperations
        ✓ should add a prepare script
        ✓ should add the husky package
        when the language is TypeScript
          ✓ should add a prepare script which builds the app (1 ms)
        when the features include commit message linting
          ✓ should add a commit message validation script (1 ms)
          ✓ should add the @commitlint/cli package
          ✓ should add the @commitlint/config-conventional package
          ✓ should add the commitizen package
          ✓ should add the cz-conventional-changelog package
        when the features include pre commit
          ✓ should add the init secrets script
          ✓ should add the lint-staged package
          ✓ should add the shellcheck package
          ✓ should add the sort-package-json package
          ✓ should add the @ls-lint/ls-lint package
      asyncOperations
        ✓ should print a muted and a success message (1 ms)
        ✓ should create a .husky directory
        ✓ should copy the husky .gitignore (1 ms)
        when the features include commitMsgLint
          ✓ should copy the commit lint config file
          ✓ should copy the Commitzen config file
          ✓ should copy the commit msg hook (1 ms)
        when the features include preCommit
          ✓ should create a scripts directory
          ✓ should copy the pre-commit hook
          ✓ should copy the lintstaged config
          ✓ should copy the ls-lint config (1 ms)
          ✓ should copy the pre-commit config
          ✓ should copy the detect-secrets script (1 ms)
          ✓ should copy the secrets baseline file
        when the features include prePush
          ✓ should copy the pre-push hook
        when an error is thrown
          ✓ should rethrow the error with an added user-friendly message (3 ms)
```