### PR TITLE
test: add jest config extension tests

### DIFF
--- a/src/extensions/jest-config-and-coverage-wf.js
+++ b/src/extensions/jest-config-and-coverage-wf.js
@@ -11,8 +11,8 @@ module.exports = (toolbox) => {
     framework,
   }) => {
     const {
-      print: { error, success, muted },
-      filesystem: { dir, copyAsync },
+      print: { success, muted },
+      filesystem: { copyAsync },
     } = toolbox
 
     async function asyncOperations() {

--- a/src/extensions/jest-config-and-coverage-wf.test.js
+++ b/src/extensions/jest-config-and-coverage-wf.test.js
@@ -1,61 +1,153 @@
-const extend = require('./jest-config-and-coverage-wf');
-const { createToolboxMock, createExtensionInput } = require('../utils/test/mocks');
+const extend = require('./jest-config-and-coverage-wf')
+const {
+  createToolboxMock,
+  createExtensionInput,
+} = require('../utils/test/mocks')
 
 describe('jest-config-and-coverage-wf', () => {
+  let toolbox
+
+  beforeEach(() => {
+    toolbox = createToolboxMock()
+    extend(toolbox)
+  })
+
   it('should be defined', () => {
-    expect(extend).toBeDefined();
-  });
+    expect(extend).toBeDefined()
+  })
 
   it('should set jestConfig on toolbox', () => {
-    const toolbox = {};
-    extend(toolbox);
-    expect(toolbox.jestConfig).toBeDefined();
-  });
+    expect(toolbox.jestConfig).toBeDefined()
+  })
 
   describe('jestConfig', () => {
-    const toolbox = createToolboxMock();
+    let input = createExtensionInput()
+    let ops
 
-    beforeAll(() => {
-      extend(toolbox);
-    });
+    beforeEach(() => {
+      ops = toolbox.jestConfig(input)
+    })
 
     it('should return syncOperations and asyncOperations when the extension is called', () => {
-      const ops = toolbox.jestConfig(createExtensionInput());
-      expect(ops.syncOperations).toBeDefined();
-      expect(ops.asyncOperations).toBeDefined();
-    });
+      expect(ops.syncOperations).toBeDefined()
+      expect(ops.asyncOperations).toBeDefined()
+    })
 
     describe('syncOperations', () => {
-      const toolbox = createToolboxMock();
-      const input = createExtensionInput();
+      let scripts
+      let packages
 
       beforeAll(() => {
-        extend(toolbox);
-        toolbox.jestConfig(input).syncOperations();
-      });
+        input.projectLanguage = 'JS'
+      })
+
+      beforeEach(() => {
+        toolbox.jestConfig(input).syncOperations()
+        scripts = Object.assign({}, ...input.pkgJsonScripts)
+        packages = input.pkgJsonInstalls.map((s) => s.split(' ')).flat(1)
+      })
 
       it('should add npm packages and scripts', () => {
-        expect(input.pkgJsonInstalls.length).toBeGreaterThan(0);
-        expect(input.pkgJsonScripts.length).toBeGreaterThan(0);
-      });
-    });
+        expect(input.pkgJsonInstalls.length).toBeGreaterThan(0)
+        expect(input.pkgJsonScripts.length).toBeGreaterThan(0)
+      })
+
+      it('should add the test script', () => {
+        expect(scripts['test']).toBe('jest')
+      })
+
+      it('should add the jest package', () => {
+        expect(packages).toContain('jest')
+      })
+
+      describe('when the languange is TypeScript', () => {
+        beforeAll(() => {
+          input.projectLanguage = 'TS'
+        })
+
+        it('should add the ts-jest package', () => {
+          expect(packages).toContain('ts-jest')
+        })
+
+        it('should add the @types/jest package', () => {
+          expect(packages).toContain('@types/jest')
+        })
+      })
+    })
 
     describe('asyncOperations', () => {
-      let toolbox = createToolboxMock();
+      beforeAll(() => {
+        input.framework = 'nest'
+      })
 
-      beforeAll(async () => {
-        toolbox.print.muted = jest.fn(() => {});
-        toolbox.print.success = jest.fn(() => {});
-        toolbox.print.error = jest.fn(() => {});
-        extend(toolbox);
-        await toolbox.jestConfig(createExtensionInput()).asyncOperations();
-      });
+      beforeEach(async () => {
+        toolbox.print.muted = jest.fn(() => {})
+        toolbox.print.success = jest.fn(() => {})
+        toolbox.print.error = jest.fn(() => {})
+        toolbox.filesystem.copyAsync = jest.fn(() => {})
+        await toolbox.jestConfig(input).asyncOperations()
+      })
 
       it('should print a muted and a success message', () => {
-        expect(toolbox.print.muted).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.success).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.error).not.toHaveBeenCalled();
-      });
-    });
-  });
-});
+        expect(toolbox.print.muted).toHaveBeenCalledTimes(1)
+        expect(toolbox.print.success).toHaveBeenCalledTimes(1)
+        expect(toolbox.print.error).not.toHaveBeenCalled()
+      })
+
+      it('should copy the coverage workflow config', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${input.assetsPath}/.github/workflows/coverage.yaml`,
+          `${input.workflowsFolder}/coverage.yaml`
+        )
+      })
+
+      describe('when the framework is not Nest', () => {
+        beforeAll(() => {
+          input.framework = 'express'
+        })
+
+        describe('when the language is TypeScript', () => {
+          beforeAll(() => {
+            input.projectLanguage = 'TS'
+          })
+
+          it('should copy the TypeScript jest config', () => {
+            expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+              `${input.assetsPath}/jest.config.ts.js`,
+              `${input.appDir}/jest.config.js`
+            )
+          })
+        })
+
+        describe('when the language is JavaScript', () => {
+          beforeAll(() => {
+            input.projectLanguage = 'JS'
+          })
+
+          it('should copy the JavaScript jest config', () => {
+            expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+              `${input.assetsPath}/jest.config.vanilla.js`,
+              `${input.appDir}/jest.config.js`
+            )
+          })
+        })
+      })
+
+      describe('when an error is thrown', () => {
+        const error = new Error('the-error')
+
+        beforeEach(async () => {
+          toolbox.filesystem.copyAsync = jest.fn(() => {
+            throw error
+          })
+        })
+
+        it('should rethrow the error with an added user-friendly message', () => {
+          expect(toolbox.jestConfig(input).asyncOperations()).rejects.toThrow(
+            `An error has occurred while copying jest configuration and workflow: ${error}`
+          )
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
```
 PASS  src/extensions/jest-config-and-coverage-wf.test.js
  jest-config-and-coverage-wf
    ✓ should be defined (2 ms)
    ✓ should set jestConfig on toolbox
    jestConfig
      ✓ should return syncOperations and asyncOperations when the extension is called
      syncOperations
        ✓ should add npm packages and scripts
        ✓ should add the test script (1 ms)
        ✓ should add the jest package
        when the languange is TypeScript
          ✓ should add the ts-jest package
          ✓ should add the @types/jest package (1 ms)
      asyncOperations
        ✓ should print a muted and a success message
        ✓ should copy the coverage workflow config (1 ms)
        when the framework is not Nest
          when the language is TypeScript
            ✓ should copy the TypeScript jest config (1 ms)
          when the language is JavaScript
            ✓ should copy the JavaScript jest config
        when an error is thrown
          ✓ should rethrow the error with an added user-friendly message (2 ms
```