### PR TITLE
test: add js-lintes and ts-setup tests

### DIFF
--- a/src/extensions/js-linters-extension.js
+++ b/src/extensions/js-linters-extension.js
@@ -12,7 +12,7 @@ module.exports = (toolbox) => {
     const {
       template: { generate },
       filesystem: { copyAsync },
-      print: { error, success, muted },
+      print: { success, muted },
     } = toolbox
 
     async function asyncOperations() {

--- a/src/extensions/js-linters-extension.test.js
+++ b/src/extensions/js-linters-extension.test.js
@@ -1,61 +1,174 @@
-const extend = require('./ts-setup');
-const { createToolboxMock, createExtensionInput } = require('../utils/test/mocks');
+const extend = require('./js-linters-extension')
+const {
+  createToolboxMock,
+  createExtensionInput,
+} = require('../utils/test/mocks')
 
-describe('ts-setup', () => {
+describe('js-linters-extension', () => {
+  let toolbox
+
+  beforeEach(() => {
+    toolbox = createToolboxMock()
+    extend(toolbox)
+  })
+
   it('should be defined', () => {
-    expect(extend).toBeDefined();
-  });
+    expect(extend).toBeDefined()
+  })
 
-  it('should set setupTs on toolbox', () => {
-    const toolbox = {};
-    extend(toolbox);
-    expect(toolbox.setupTs).toBeDefined();
-  });
+  it('should set jsLinters on toolbox', () => {
+    expect(toolbox.jsLinters).toBeDefined()
+  })
 
-  describe('setupTs', () => {
-    const toolbox = createToolboxMock();
+  describe('jsLinters', () => {
+    const input = createExtensionInput()
+    let ops
 
-    beforeAll(() => {
-      extend(toolbox);
-    });
+    beforeEach(() => {
+      ops = toolbox.jsLinters(input)
+    })
 
     it('should return syncOperations and asyncOperations when the extension is called', () => {
-      const ops = toolbox.setupTs(createExtensionInput());
-      expect(ops.syncOperations).toBeDefined();
-      expect(ops.asyncOperations).toBeDefined();
-    });
+      expect(ops.syncOperations).toBeDefined()
+      expect(ops.asyncOperations).toBeDefined()
+    })
 
     describe('syncOperations', () => {
-      const toolbox = createToolboxMock();
-      const input = createExtensionInput();
+      let scripts
+      let packages
 
       beforeAll(() => {
-        extend(toolbox);
-        toolbox.setupTs(input).syncOperations();
-      });
+        input.projectLanguage = 'JS'
+      })
 
-      it('should add npm packages and scripts', () => {
-        expect(input.pkgJsonInstalls.length).toBeGreaterThan(0);
-        expect(input.pkgJsonScripts.length).toBeGreaterThan(0);
-      });
-    });
+      beforeEach(() => {
+        toolbox.jsLinters(input).syncOperations()
+        scripts = Object.assign({}, ...input.pkgJsonScripts)
+        packages = input.pkgJsonInstalls.map((s) => s.split(' ')).flat(1)
+      })
+
+      it('should add a prettier:format script', () => {
+        expect(scripts['prettier:format']).toBe('prettier . --write')
+      })
+
+      it('should add a prettier:check-format script', () => {
+        expect(scripts['prettier:check-format']).toBe(
+          'prettier . --list-different'
+        )
+      })
+
+      describe('when the language is TypeScript', () => {
+        beforeAll(() => {
+          input.projectLanguage = 'TS'
+        })
+
+        it('should add a lint script', () => {
+          expect(scripts['lint']).toBe('eslint . --ext .js,.cjs,.mjs,.ts')
+        })
+
+        it('should add the @typescript-eslint/eslint-plugin package', () => {
+          expect(packages).toContain('@typescript-eslint/eslint-plugin')
+        })
+
+        it('should add the @typescript-eslint/parser package', () => {
+          expect(packages).toContain('@typescript-eslint/parser')
+        })
+      })
+
+      describe('when the language is JavaScript', () => {
+        beforeAll(() => {
+          input.projectLanguage = 'JS'
+        })
+
+        it('should add a lint script', () => {
+          expect(scripts['lint']).toBe('eslint . --ext .js,.cjs,.mjs')
+        })
+      })
+
+      it('should add a lint:fix script', () => {
+        expect(scripts['lint:fix']).toBe('npm run lint --fix')
+      })
+
+      it('should add the prettier package', () => {
+        expect(packages).toContain('prettier')
+      })
+
+      it('should add the eslint package', () => {
+        expect(packages).toContain('eslint')
+      })
+
+      it('should add the eslint-config-prettier package', () => {
+        expect(packages).toContain('eslint-config-prettier')
+      })
+
+      it('should add the eslint-config-google package', () => {
+        expect(packages).toContain('eslint-config-google')
+      })
+
+      it('should add the eslint-plugin-prettier package', () => {
+        expect(packages).toContain('eslint-plugin-prettier')
+      })
+    })
 
     describe('asyncOperations', () => {
-      let toolbox = createToolboxMock();
-
-      beforeAll(async () => {
-        toolbox.print.muted = jest.fn(() => {});
-        toolbox.print.success = jest.fn(() => {});
-        toolbox.print.error = jest.fn(() => {});
-        extend(toolbox);
-        await toolbox.setupTs(createExtensionInput()).asyncOperations();
-      });
+      beforeEach(async () => {
+        toolbox.print.muted = jest.fn(() => {})
+        toolbox.print.success = jest.fn(() => {})
+        toolbox.print.error = jest.fn(() => {})
+        toolbox.template.generate = jest.fn(() => {})
+        toolbox.filesystem.copyAsync = jest.fn(() => {})
+        await toolbox.jsLinters(input).asyncOperations()
+      })
 
       it('should print a muted and a success message', () => {
-        expect(toolbox.print.muted).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.success).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.error).not.toHaveBeenCalled();
-      });
-    });
-  });
-});
+        expect(toolbox.print.muted).toHaveBeenCalledTimes(1)
+        expect(toolbox.print.success).toHaveBeenCalledTimes(1)
+        expect(toolbox.print.error).not.toHaveBeenCalled()
+      })
+
+      it('should generate an eslint config', () => {
+        expect(toolbox.template.generate).toHaveBeenCalled()
+        const opts = toolbox.template.generate.mock.calls[0][0]
+        expect(opts.template).toBe('eslintrc-model.js.ejs')
+        expect(opts.target).toBe(`${input.appDir}/.eslintrc.js`)
+      })
+
+      it('should generate a prettier config', () => {
+        expect(toolbox.template.generate).toHaveBeenCalledTimes(2)
+        const opts = toolbox.template.generate.mock.calls[1][0]
+        expect(opts.template).toBe('prettierrc-model.js.ejs')
+        expect(opts.target).toBe(`${input.appDir}/.prettierrc.js`)
+      })
+
+      it('should copy the .eslintignore file', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${input.assetsPath}/.eslintignore`,
+          `${input.appDir}/.eslintignore`
+        )
+      })
+
+      it('should copy the prettier ignore fire', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${input.assetsPath}/.prettierignore`,
+          `${input.appDir}/.prettierignore`
+        )
+      })
+
+      describe('when an error is thrown', () => {
+        const error = new Error('the-error')
+
+        beforeEach(() => {
+          toolbox.template.generate = jest.fn(() => {
+            throw error
+          })
+        })
+
+        it('should rethrow the error with an added user-friendly message', () => {
+          expect(toolbox.jsLinters(input).asyncOperations()).rejects.toThrow(
+            `An error has occurred while executing JS linters configuration: ${error}`
+          )
+        })
+      })
+    })
+  })
+})

--- a/src/extensions/ts-setup.js
+++ b/src/extensions/ts-setup.js
@@ -11,7 +11,7 @@ module.exports = (toolbox) => {
   }) => {
     const {
       filesystem: { copyAsync, copy, write, read },
-      print: { error, success, muted },
+      print: { success, muted },
     } = toolbox
 
     async function asyncOperations() {

--- a/src/extensions/ts-setup.test.js
+++ b/src/extensions/ts-setup.test.js
@@ -1,61 +1,188 @@
-const extend = require('./js-linters-extension');
-const { createToolboxMock, createExtensionInput } = require('../utils/test/mocks');
+const extend = require('./ts-setup')
+const {
+  createToolboxMock,
+  createExtensionInput,
+} = require('../utils/test/mocks')
 
-describe('js-linters-extension', () => {
+describe('ts-setup', () => {
+  let toolbox
+
+  beforeEach(() => {
+    toolbox = createToolboxMock()
+    extend(toolbox)
+  })
+
   it('should be defined', () => {
-    expect(extend).toBeDefined();
-  });
+    expect(extend).toBeDefined()
+  })
 
-  it('should set jsLinters on toolbox', () => {
-    const toolbox = {};
-    extend(toolbox);
-    expect(toolbox.jsLinters).toBeDefined();
-  });
+  it('should set setupTs on toolbox', () => {
+    expect(toolbox.setupTs).toBeDefined()
+  })
 
-  describe('jsLinters', () => {
-    const toolbox = createToolboxMock();
+  describe('setupTs', () => {
+    const input = createExtensionInput()
+    let ops
 
-    beforeAll(() => {
-      extend(toolbox);
-    });
+    beforeEach(() => {
+      ops = toolbox.setupTs(input)
+    })
 
     it('should return syncOperations and asyncOperations when the extension is called', () => {
-      const ops = toolbox.jsLinters(createExtensionInput());
-      expect(ops.syncOperations).toBeDefined();
-      expect(ops.asyncOperations).toBeDefined();
-    });
+      expect(ops.syncOperations).toBeDefined()
+      expect(ops.asyncOperations).toBeDefined()
+    })
 
     describe('syncOperations', () => {
-      const toolbox = createToolboxMock();
-      const input = createExtensionInput();
+      let scripts
+      let packages
 
       beforeAll(() => {
-        extend(toolbox);
-        toolbox.jsLinters(input).syncOperations();
-      });
+        input.framework = 'nest'
+      })
 
-      it('should add npm packages and scripts', () => {
-        expect(input.pkgJsonInstalls.length).toBeGreaterThan(0);
-        expect(input.pkgJsonScripts.length).toBeGreaterThan(0);
-      });
-    });
+      beforeEach(() => {
+        toolbox.filesystem.copy = jest.fn(() => {})
+        toolbox.filesystem.read = jest.fn(() =>
+          JSON.stringify({ compilerOptions: {} })
+        )
+        toolbox.filesystem.write = jest.fn(() => {})
+        toolbox.setupTs(input).syncOperations()
+        scripts = Object.assign({}, ...input.pkgJsonScripts)
+        packages = input.pkgJsonInstalls.map((s) => s.split(' ')).flat(1)
+      })
+
+      describe('when the framework is not Nest', () => {
+        beforeAll(() => {
+          input.framework = 'express'
+          input.pkgJsonScripts = []
+          input.pkgJsonInstalls = []
+        })
+
+        it('should copy the tsconfig file', () => {
+          expect(toolbox.filesystem.copy).toHaveBeenCalledWith(
+            `${input.assetsPath}/tsconfig.json`,
+            `${input.appDir}/tsconfig.json`
+          )
+        })
+
+        it('should add a build script', () => {
+          expect(scripts['build']).toBe('tsc --build && tsc-alias')
+        })
+
+        it('should add a prepare script', () => {
+          expect(scripts['prepare']).toBe('npm run build')
+        })
+
+        it('should add the typescript package', () => {
+          expect(packages).toContain('typescript')
+        })
+
+        it('should add the @tsconfig/recommended package', () => {
+          expect(packages).toContain('@tsconfig/recommended')
+        })
+
+        it('should add the tsc-alias package', () => {
+          expect(packages).toContain('tsc-alias')
+        })
+      })
+
+      describe('when the framework is Nest', () => {
+        beforeAll(() => {
+          input.framework = 'nest'
+          input.pkgJsonScripts = []
+          input.pkgJsonInstalls = []
+        })
+
+        it('should not copy the tsconfig', () => {
+          expect(toolbox.filesystem.copy).not.toHaveBeenCalled()
+        })
+
+        it('should not add any scripts or packages', () => {
+          expect(Object.keys(scripts).length).toBe(0)
+          expect(packages.length).toBe(0)
+        })
+      })
+
+      describe('when the module system is ESM', () => {
+        beforeAll(() => {
+          input.moduleType = 'ESM'
+        })
+
+        it('should update the tsconfig file', () => {
+          expect(toolbox.filesystem.read).toHaveBeenCalledWith(
+            `${input.appDir}/tsconfig.json`
+          )
+          expect(toolbox.filesystem.write).toHaveBeenCalled()
+          const config = toolbox.filesystem.write.mock.calls[0][1]
+          expect(config.compilerOptions.module).toBe('ES2015')
+        })
+      })
+    })
 
     describe('asyncOperations', () => {
-      let toolbox = createToolboxMock();
+      beforeEach(async () => {
+        toolbox.print.muted = jest.fn(() => {})
+        toolbox.print.success = jest.fn(() => {})
+        toolbox.print.error = jest.fn(() => {})
+        toolbox.filesystem.copyAsync = jest.fn(() => {})
+        await toolbox.setupTs(input).asyncOperations()
+      })
 
-      beforeAll(async () => {
-        toolbox.print.muted = jest.fn(() => {});
-        toolbox.print.success = jest.fn(() => {});
-        toolbox.print.error = jest.fn(() => {});
-        extend(toolbox);
-        await toolbox.jsLinters(createExtensionInput()).asyncOperations();
-      });
+      describe('when the framework is not Nest', () => {
+        beforeAll(() => {
+          input.framework = 'express'
+        })
 
-      it('should print a muted and a success message', () => {
-        expect(toolbox.print.muted).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.success).toHaveBeenCalledTimes(1);
-        expect(toolbox.print.error).not.toHaveBeenCalled();
-      });
-    });
-  });
-});
+        it('should print a muted and a success message', () => {
+          expect(toolbox.print.muted).toHaveBeenCalledTimes(1)
+          expect(toolbox.print.success).toHaveBeenCalledTimes(1)
+          expect(toolbox.print.error).not.toHaveBeenCalled()
+        })
+
+        it('should copy the tsconfig file', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${input.assetsPath}/tsconfig.build.json`,
+            `${input.appDir}/tsconfig.build.json`
+          )
+        })
+      })
+
+      describe('when the framework is Nest', () => {
+        beforeAll(() => {
+          input.framework = 'nest'
+        })
+
+        it('should not a muted nor a success message', () => {
+          expect(toolbox.print.muted).not.toHaveBeenCalled()
+          expect(toolbox.print.success).not.toHaveBeenCalled()
+          expect(toolbox.print.error).not.toHaveBeenCalled()
+        })
+
+        it('should not copy anything', () => {
+          expect(toolbox.filesystem.copyAsync).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('when an error is thrown', () => {
+        const error = new Error('the-error')
+
+        beforeAll(() => {
+          input.framework = 'express'
+        })
+
+        beforeEach(() => {
+          toolbox.filesystem.copyAsync = jest.fn(() => {
+            throw error
+          })
+        })
+
+        it('should rethrow the error with an added user-friendly message', () => {
+          expect(toolbox.setupTs(input).asyncOperations()).rejects.toThrow(
+            `An error has occurred while executing TS configuration: ${error}`
+          )
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
```
 PASS  src/extensions/js-linters-extension.test.js
  js-linters-extension
    ✓ should be defined (2 ms)
    ✓ should set jsLinters on toolbox (1 ms)
    jsLinters
      ✓ should return syncOperations and asyncOperations when the extension is called
      syncOperations
        ✓ should add a prettier:format script (1 ms)
        ✓ should add a prettier:check-format script
        ✓ should add a lint:fix script
        ✓ should add the prettier package
        ✓ should add the eslint package
        ✓ should add the eslint-config-prettier package
        ✓ should add the eslint-config-google package (1 ms)
        ✓ should add the eslint-plugin-prettier package
        when the language is TypeScript
          ✓ should add a lint script
          ✓ should add the @typescript-eslint/eslint-plugin package
          ✓ should add the @typescript-eslint/parser package
        when the language is JavaScript
          ✓ should add a lint script (1 ms)
      asyncOperations
        ✓ should print a muted and a success message
        ✓ should generate an eslint config (1 ms)
        ✓ should generate a prettier config
        ✓ should copy the .eslintignore file (1 ms)
        ✓ should copy the prettier ignore fire
        when an error is thrown
          ✓ should rethrow the error with an added user-friendly message (3 ms)
```

```
 PASS  src/extensions/ts-setup.test.js
  ts-setup
    ✓ should be defined (2 ms)
    ✓ should set setupTs on toolbox
    setupTs
      ✓ should return syncOperations and asyncOperations when the extension is called (1 ms)
      syncOperations
        when the framework is not Nest
          ✓ should copy the tsconfig file (2 ms)
          ✓ should add a build script
          ✓ should add a prepare script (1 ms)
          ✓ should add the typescript package
          ✓ should add the @tsconfig/recommended package (1 ms)
          ✓ should add the tsc-alias package
        when the framework is Nest
          ✓ should not copy the tsconfig (1 ms)
          ✓ should not add any scripts or packages
        when the module system is ESM
          ✓ should update the tsconfig file (1 ms)
      asyncOperations
        when the framework is not Nest
          ✓ should print a muted and a success message (1 ms)
          ✓ should copy the tsconfig file
        when the framework is Nest
          ✓ should not a muted nor a success message
          ✓ should not copy anything
        when an error is thrown
          ✓ should rethrow the error with an added user-friendly message (2 ms)
```